### PR TITLE
Refactor/ansible

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,17 @@
+---
+profile: min # null, min, basic, moderate,safety, shared, production
+exclude_paths:
+  - .git/
+  - .github/
+  - .vscode/
+enable_list:
+  - fqcn-builtins  # opt-in
+warn_list:
+  - line-length
+  - yaml[line-length]
+skip_list:
+  - risky-file-permissions
+  - 'Command .* returned non-zero exit status 1'  # Generic pattern for all failed commands (cf. utf-8 errors)
+  - name[play]
+  - package-latest
+offline: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,36 @@
-hosts.ini
+# ETC
+ansible.cfg
+hosts*
+facts/*
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# INCLUDE
+!**/*.example
+!**/.gitkeep

--- a/README.md
+++ b/README.md
@@ -28,23 +28,21 @@ cd kamal-ansible-manager
 Copy the example files:
 
 ```bash
-$ cp hosts.ini.example hosts.ini
+cp hosts.ini.example hosts.ini
+cp ansible.cfg.example ansible.cfg
 ```
 
-Update the `<host1>` with your server's IP address (you can have multiple servers):
-```bash
-$ vim hosts.ini
-```
+Update the `<host1>` in `hosts.ini` with your server's IP address (you can have multiple servers):
 
 Run the playbook:
 
 ```bash
-$ ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i hosts.ini playbook.yml
+ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i hosts.ini playbook.yml
 ```
 
 ## Contributing
 
-Do not hesitate to contribute to the project by adapting or adding features ! Bug reports or pull requests are welcome.
+Do not hesitate to contribute to the project by adapting or adding features! Bug reports or pull requests are welcome.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,21 @@ It will automatically update your packages and configure these packages to secur
 - [NTP](https://ubuntu.com/server/docs/network-ntp)
 
 The playbook also:
-- Remove [Snap](https://snapcraft.io/).
-- Disable ssh password login.
+
+- Removes [Snap](https://snapcraft.io/).
+- Disables ssh password login.
 
 ## Getting Started
 
 Clone the repo:
+
 ```bash
-$ git clone git@github.com:guillaumebriday/kamal-ansible-manager.git
-$ cd kamal-ansible-manager
+git clone git@github.com:guillaumebriday/kamal-ansible-manager.git
+cd kamal-ansible-manager
 ```
 
-Copy the inventory example file:
+Copy the example files:
+
 ```bash
 $ cp hosts.ini.example hosts.ini
 ```
@@ -34,6 +37,7 @@ $ vim hosts.ini
 ```
 
 Run the playbook:
+
 ```bash
 $ ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i hosts.ini playbook.yml
 ```

--- a/ansible.cfg.example
+++ b/ansible.cfg.example
@@ -1,6 +1,6 @@
 [defaults]
 log_path                    = /var/log/ansible.log
-inventory                   = ./hosts
+inventory                   = ./hosts.ini
 roles_path                  = ./roles
 host_key_checking           = False
 retry_files_enabled         = False

--- a/ansible.cfg.example
+++ b/ansible.cfg.example
@@ -1,0 +1,16 @@
+[defaults]
+log_path                    = /var/log/ansible.log
+inventory                   = ./hosts
+roles_path                  = ./roles
+host_key_checking           = False
+retry_files_enabled         = False
+remote_tmp                  = /tmp/${USER}/ansible
+gathering                   = smart
+fact_caching                = jsonfile
+fact_caching_connection     = ./facts
+fact_caching_prefix         = ansible_facts_
+fact_caching_timeout        = 300
+# fact_caching                = redis
+# fact_caching_connection     = localhost:6379:0
+# strategy                    = mitogen_linear
+# strategy_plugins            = ~/.local/bin/strategy

--- a/hosts.ini.example
+++ b/hosts.ini.example
@@ -1,2 +1,9 @@
+[all]
+localhost               ansible_connection=local
+
 [webservers]
-<host1> ansible_become_method=su ansible_user=root
+<host1>
+
+[all:vars]
+ansible_become_method=su
+ansible_user=root

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,7 @@
 ---
-- name: Provisionning webservers group
+- name: Provisioning webservers group
   hosts: webservers
+  become: true
   strategy: free
   roles:
     - packages

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,28 +1,38 @@
 ---
 - name: Ensure old versions of Docker are not installed
-  package:
+  ansible.builtin.package:
     name:
       - docker
       - docker.io
       - docker-engine
     state: absent
+  tags: docker
 
-- name: Add Docker apt key
-  get_url:
+- name: Create directory for Docker GPG key
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+  tags: docker
+
+- name: Add Docker GPG apt key
+  ansible.builtin.get_url:
     url: "https://download.docker.com/linux/ubuntu/gpg"
-    dest: /etc/apt/trusted.gpg.d/docker.asc
-    mode: 0644
-    force: false
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
+    force: true
+  tags: docker
 
 - name: Add Docker repository
-  apt_repository:
-    repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+  ansible.builtin.apt_repository:
+    repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
     state: present
     filename: docker
     update_cache: true
+  tags: docker
 
 - name: Install Docker packages
-  package:
+  ansible.builtin.package:
     name:
       - docker-ce
       - docker-ce-cli
@@ -30,3 +40,4 @@
     state: present
   notify:
     - restart docker
+  tags: docker

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Configure ufw defaults
-  ufw:
+  community.general.ufw:
     direction: "{{ item.direction }}"
     policy: "{{ item.policy }}"
   loop:
@@ -8,9 +8,10 @@
       policy: deny
     - direction: outgoing
       policy: allow
+  tags: firewall
 
 - name: Configure ufw rules
-  ufw:
+  community.general.ufw:
     rule: "{{ item.rule }}"
     port: "{{ item.port }}"
     proto: "{{ item.proto }}"
@@ -24,7 +25,9 @@
     - rule: 'allow'
       port: '443'
       proto: 'tcp'
+  tags: firewall
 
 - name: Enable ufw
-  ufw:
+  community.general.ufw:
     state: enabled
+  tags: firewall

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -1,11 +1,12 @@
 ---
 - name: Upgrade packages
-  apt:
-    update_cache: yes
-    upgrade: yes
+  ansible.builtin.apt:
+    update_cache: true
+    upgrade: true
+  tags: pkg
 
 - name: Install packages
-  apt:
+  ansible.builtin.apt:
     name:
       - apt-transport-https
       - build-essential
@@ -20,9 +21,10 @@
       - unattended-upgrades
       - vim
     state: latest
-    update_cache: yes
-    autoremove: yes
-    autoclean: yes
+    update_cache: true
+    autoremove: true
+    autoclean: true
   notify:
     - start ntp
     - start fail2ban
+  tags: pkg

--- a/roles/snap/tasks/main.yml
+++ b/roles/snap/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
 - name: Remove snap
-  apt:
+  ansible.builtin.apt:
     name:
       - snapd
       - snap
     state: absent
     purge: true
+  tags: snap

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Update SSH configuration to be more secure
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: "/etc/ssh/sshd_config"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
@@ -26,3 +26,4 @@
       line: "X11Forwarding no"
   notify:
     - restart ssh
+  tags: ssh


### PR DESCRIPTION
Hi @guillaumebriday! Appreciate your work on this!

Made some admittedly opinionated changes — although most of them come from linting and ansible norms — that I thought you might appreciate.

Happy to expand on the following, but these are the high-level modifications:

## docs

- readme: remove non-root `$` prefixes, add ansible.cfg.example, fix typo
- ansible.cfg.example: rename to hosts.ini to match upstream
- hosts.ini.example: add all config for localhost and vars, move become method and user to vars

## refactor

- add become to playbook for non-root sudoers
- FQCNs (builtin vs. community)
- fix docker gpg key (keyrings directory, implicit octal notation)
- tags (selectively run roles)
- add ansible.cfg.example w/facts directory placeholder
- add .ansible-lint
- update .gitignore
