### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ $ vim hosts.ini
 
 Install the requirements:
 ```bash
-$ ansible-galaxy collection install -r requirements.yml
-$ ansible-galaxy role install -r requirements.yml
+$ ansible-galaxy install -r requirements.yml
 ```
 
 ## Configuring vars

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ $ vim hosts.ini
 Install the requirements:
 ```bash
 $ ansible-galaxy collection install -r requirements.yml
+$ ansible-galaxy role install -r requirements.yml
 ```
 
 ## Configuring vars


### PR DESCRIPTION
When I ran the playbook using the following command 
```bash
$ ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i hosts.ini playbook.yml
```

I ran into the following error:
```bash
ERROR! the role 'geerlingguy.swap' was not found in ~/kamal-deploy/roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:~/kamal-deploy

The error appears to be in '~/kamal-deploy/playbook.yml': line 15, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    - security
    - geerlingguy.swap
      ^ here
```

The updated readme command installs the missing dependency.